### PR TITLE
Yaml serialization with common ancestors.

### DIFF
--- a/lib/core/rails_translation_store.rb
+++ b/lib/core/rails_translation_store.rb
@@ -50,16 +50,28 @@ class RailsTranslationStore < BaseTranslationStore
   # and serialize the hash
   def serialize
     to_return = "#{@language}:\n"
-    last_context = nil
+    last_context_array = []
     self.each do |context, key, value|
       whitespace_depth = 2
+      new_context_array = []
       context_array = context.split('/')
-      context_array.each do |split_context|
-        to_return << "#{build_whitespace( whitespace_depth )}#{split_context}:\n" 
+
+      context_array.zip(last_context_array) do |new, old|
+        if new != old || new_context_array.any?
+          new_context_array << new
+        else
+          new_context_array << nil
+        end
+      end
+
+      new_context_array.each do |split_context|
+        if split_context != nil
+          to_return << "#{build_whitespace( whitespace_depth )}#{split_context}:\n"
+        end
         whitespace_depth += 2
-      end unless context == last_context
-        to_return << "#{build_whitespace( 2 + 2 * context_array.length )}#{key}: \"#{escape(value)}\"\n"
-      last_context = context
+      end
+      to_return << "#{build_whitespace( 2 + 2 * context_array.length )}#{key}: \"#{escape(value)}\"\n"
+      last_context_array = context_array
     end
     
     to_return.chomp

--- a/tests/specs/rails_translation_store_spec.rb
+++ b/tests/specs/rails_translation_store_spec.rb
@@ -143,6 +143,29 @@ SIMPLE_KEY_VALUE
     
   end
 
+  it "should serialize to yaml properly with nested items that share a common ancestor properly" do
+    store = RailsTranslationStore.new
+    store.start_new_context( "foo/bar/baz" )
+    store.add_translation( "key", "value" )
+    store.add_translation( "key2", "value2" )
+    store.start_new_context( "foo/bar/buz" )
+    store.add_translation( "key", "value" )
+    store.add_translation( "key3", "value3" )
+
+    resulting_string =<<SIMPLE_KEY_VALUE
+en:
+  foo:
+    bar:
+      baz:
+        key: "value"
+        key2: "value2"
+      buz:
+        key: "value"
+        key3: "value3"
+SIMPLE_KEY_VALUE
+    store.serialize.should == resulting_string.strip
+  end
+
   it "should be able to handle multiple contexts with multiple keys" do
     store = RailsTranslationStore.new
     store.start_new_context( "test" )


### PR DESCRIPTION
Fixed a bug in the YAML serialization where it was YAML that was overwriting
translation blocks when keys shared a common ancestor.

Old:

```
en:
  foo:
    bar:
      baz:
        key = value
    bar:
      buz:
        key2 = value2
```

New:

```
en:
  foo:
    bar:
      baz:
        key = value
      buz:
        key2 = value2
```
