### PR TITLE
Kludge to read all views as UTF8

### DIFF
--- a/lib/core/erb_file.rb
+++ b/lib/core/erb_file.rb
@@ -83,7 +83,7 @@ class ErbFile
   end
   
   def ErbFile.load( file_path )
-    ErbFile.parse( File.read( file_path ) )
+    ErbFile.parse( File.read( file_path, encoding: Encoding::UTF_8 ) )
   end
 
   def serialize


### PR DESCRIPTION
This makes sure that all views are read in UTF8 so it doesn't crash on regular expressions.
