### PR TITLE
Fix loading of YAML files with nested keys.

### DIFF
--- a/lib/core/rails_translation_store.rb
+++ b/lib/core/rails_translation_store.rb
@@ -27,9 +27,10 @@ class RailsTranslationStore < BaseTranslationStore
     to_return
   end
 
-  def self.process_yaml_pair( translation_store, key, value, directory_like_key )
+  def self.process_yaml_pair( translation_store, key, value, base_directory_like_key )
     if( value.is_a?( Hash ) )
       value.each_pair do |key, value|
+        directory_like_key = base_directory_like_key
         if( value.is_a?( Hash ) )
           directory_like_key = "#{directory_like_key}/" unless directory_like_key.empty?
           directory_like_key = "#{directory_like_key}#{key}"
@@ -38,7 +39,7 @@ class RailsTranslationStore < BaseTranslationStore
       end
       translation_store
     else
-      translation_store.start_new_context( directory_like_key )      
+      translation_store.start_new_context( base_directory_like_key )
       translation_store.add_translation( key, value )
       translation_store
     end

--- a/tests/specs/rails_translation_store_spec.rb
+++ b/tests/specs/rails_translation_store_spec.rb
@@ -265,13 +265,17 @@ VALUE_STRING
   it "should be able to load an existing yml file" do
     yaml_string =<<YAML_STRING
 en:
-  test:
-    key: "value"
+  key1:
+    key1-1:
+      key1-1-1: value1
+    key1-2:
+      key1-2-1: value2
 YAML_STRING
 
     store = RailsTranslationStore.load_from_string( yaml_string )
     yaml_result = YAML.load( store.serialize )    
-    yaml_result['en']['test']['key'].should == 'value'
+    yaml_result['en']['key1']['key1-1']['key1-1-1'].should == 'value1'
+    yaml_result['en']['key1']['key1-2']['key1-2-1'].should == 'value2'
   end
 
   it "should be able to load an existing yml file with much deeper nesting of files" do


### PR DESCRIPTION
We were improperly loading nested keys by leaking directory keys between Hash key/value pairs at the same level.
