### PR TITLE
Fixed text block extraction to handle HTML strings

### DIFF
--- a/grammer/erb_grammer.treetop
+++ b/grammer/erb_grammer.treetop
@@ -15,7 +15,7 @@ grammar ERBGrammer
          end
 
         rule method_names             
-             "link_to_function" / "link_to"  <NonTextNode>
+             "link_to_function" / "link_to" / "button_to" <NonTextNode>
              {
                 def node_name  
                     "method_names"
@@ -322,7 +322,7 @@ grammar ERBGrammer
         end
 
         rule tag_text
-            (!'>' !'/>' ( tag_to_process / erb_block / erb_string / . ) )* <NonTextNode>
+            (!'>' ( tag_to_process / erb_block / erb_string / . ) )* <NonTextNode>
             {
                def node_name
                    "tag_text"

--- a/lib/core/i18n_key.rb
+++ b/lib/core/i18n_key.rb
@@ -19,6 +19,7 @@ class I18nKey
       to_return = to_return.gsub( / /, '_' )
       to_return = cut_down_to_size( to_return )
       to_return = ensure_no_duplicates( to_return )
+      to_return = "#{to_return}_html" if @text =~ /<[\/]?[a-zA-Z]+[^<]*>/
       self.key_value = to_return
     end
     @key_value

--- a/tests/specs/i8n_key_spec.rb
+++ b/tests/specs/i8n_key_spec.rb
@@ -29,7 +29,7 @@ describe I18nKey do
 
   it "should remove the extra html tags" do
     text_call = I18nKey.new( ' Doug<a href="www.google">is great</a>yay!' )
-    text_call.key_value.should == "doug_is_great"
+    text_call.key_value.should == "doug_is_great_html"
   end
 
   it "should handle line breaks correctly" do
@@ -39,7 +39,7 @@ Doug
                                 yay!
 TEXT
     text_call = I18nKey.new( text )
-    text_call.key_value.should == "doug_is_great"
+    text_call.key_value.should == "doug_is_great_html"
   end
 
   it "should be able to eliminate the pipe character as a possible character" do

--- a/tests/specs/rails_text_extractor_spec.rb
+++ b/tests/specs/rails_text_extractor_spec.rb
@@ -34,7 +34,7 @@ describe RailsTextExtractor do
     text_extractor = RailsTextExtractor.new    
     erb_file.extract_text( text_extractor )
     erb_file.nodes.size.should == 1
-    erb_file.nodes.first.text_value.should == "<%= t '.blah_yay' %>"
+    erb_file.nodes.first.text_value.should == "<%= t '.blah_yay_html' %>"
   end
 
   it "should be able to combine several text nodes passed in to a single value" do


### PR DESCRIPTION
Fixed tag_text to not exclude tags that have self ending slashes.

Made translation keys follow the Rails convention of adding _html to
the key to have it escape HTML.
