### PR TITLE
Add support for custom extensions, rewrite with optparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The HerbGobbler is very much beta software.  It attempts to implement the best p
 
 Experimental TR8N Support
 -------------------------
-The Herbgobbler also has experimental <a href="http://www.tr8n.net/">tr8n</a> support.  By running:
+The Herbgobbler also has experimental <a href="https://github.com/tr8n/tr8n">tr8n</a> support.  By running:
           $ gobble -tr8n -a ~/my/rails/root
 
 The Herbgobbler will rewrite your erb files with tr8n embed (tr) tags.  This is a more beta feature than the rest of the Herbgobbler.  If you discover any problems please submit a bug through github being sure to include the block of erb that is causing problems.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ The Herbgobbler also has experimental <a href="https://github.com/tr8n/tr8n">tr8
 
 The Herbgobbler will rewrite your erb files with tr8n embed (tr) tags.  This is a more beta feature than the rest of the Herbgobbler.  If you discover any problems please submit a bug through github being sure to include the block of erb that is causing problems.
 
+Command Line Options
+--------------------
+HerbGobbler provides several command line options to make text extraction simppler
+* -a / --path : Defines the root of the Rails project
+* -e / --extension : Defines the extension of the files that will be converted, without a preceeding period.
+* -f / --file : Defines a single file to extract text from
+
 Customizing the HerbGobbler
 ----------------------------
 If you are interested in exporting text to a different data store than the default rails i18n format (en.yml), this can be done by implementing a <a href="https://github.com/douglasjsellers/herbgobbler/blob/master/lib/core/base_translation_store.rb">TranslationStore</a>.  

--- a/bin/gobble
+++ b/bin/gobble
@@ -1,42 +1,50 @@
 #!/usr/bin/env ruby
 require 'herbgobbler'
+require 'optparse'
 
 def print_usage
   puts " ***** HerbGobbler Usage ***** "
   puts
   puts "Options "
   puts "tr8n | i18n : Use the normal rails i18n output format or use tr8n output"
-  puts "-a : Process an entire Rails Code Base"
+  puts "-a : Process an entire Rails Code Base : Default is the current directory"
   puts "-e : Use a custom file extension : Default is .html.erb"
   puts "-f <full path to file> : Process a single file"
   puts
   puts "Usage: gobble tr8n -a <rails root>"
 end
 
-if( ARGV.length < 3 )
+options = {}
+OptionParser.new do |opts|
+  opts.on("-e", "--extension EXTENSION", "Custom extension") do |v|
+    options[:extension] = v
+  end
+
+  opts.on("-a", "--path RAILSROOT", "Specify the root of the rails project") do |v|
+    options[:path] = v
+  end
+
+  opts.on("-f", "--file FILEPATH", "Specify a single file to process") do |v|
+    options[:file] = v
+  end
+end.parse!
+
+type = ARGV.pop
+ext = options[:extension] || "html.erb"
+path = options[:path] || "."
+file = options[:file]
+
+if !type
   print_usage
 else
-  type = ARGV.shift
-  option = ARGV.shift
-  rails_root = ARGV.pop
-  case option
-  when "-a"
-    command_line_object = GobbleAll.new( rails_root, type, ext, ARGV )    
-  when "-f"
-    command_line_object = GobbleSingleFile.new( rails_root, type, ARGV )
+  if path
+    command_line_executable = GobbleAll.new( path, type, ext, ARGV ) 
+  elsif file
+    command_line_executable = GobbleSingleFile.new( path, type, ARGV )
   else
     print_usage
   end
-  
-  
-  if( !command_line_object.nil? && command_line_object.valid? )
-    command_line_object.execute    
-  else
-    print_usage
+  if !command_line_executable.nil? && command_line_executable.valid?
+    command_line_executable.execute
   end
-  
-
-
-  
 end
-

--- a/bin/gobble
+++ b/bin/gobble
@@ -7,6 +7,7 @@ def print_usage
   puts "Options "
   puts "tr8n | i18n : Use the normal rails i18n output format or use tr8n output"
   puts "-a : Process an entire Rails Code Base"
+  puts "-e : Use a custom file extension : Default is .html.erb"
   puts "-f <full path to file> : Process a single file"
   puts
   puts "Usage: gobble tr8n -a <rails root>"
@@ -20,7 +21,7 @@ else
   rails_root = ARGV.pop
   case option
   when "-a"
-    command_line_object = GobbleAll.new( rails_root, type, ARGV )    
+    command_line_object = GobbleAll.new( rails_root, type, ext, ARGV )    
   when "-f"
     command_line_object = GobbleSingleFile.new( rails_root, type, ARGV )
   else

--- a/lib/commandline/gobble_all.rb
+++ b/lib/commandline/gobble_all.rb
@@ -1,10 +1,11 @@
 class GobbleAll
   include GobbleShare
   
-  def initialize( rails_root, type, options )
+  def initialize( rails_root, type, ext, options )
     @rails_root = rails_root
     @options = options
     @text_extractor_type = type
+    @extension = ext
   end
 
   def execute
@@ -30,7 +31,7 @@ class GobbleAll
     rails_view_directory = "#{@rails_root}/app/views"
     text_extractor = Tr8nTextExtractor.new
     
-    Dir["#{rails_view_directory}/**/*html.erb" ].each do |full_erb_file_path|
+    Dir["#{rails_view_directory}/**/*#{@extension}" ].each do |full_erb_file_path|
       
       erb_file = full_erb_file_path.gsub( @rails_root, '' )
       erb_file = ErbFile.load( full_erb_file_path )
@@ -51,7 +52,7 @@ class GobbleAll
     rails_translation_store = RailsTranslationStore.load_from_file( full_yml_file_path )
     text_extractor = RailsTextExtractor.new( rails_translation_store )
     
-    Dir["#{rails_view_directory}/**/*html.erb" ].each do |full_erb_file_path|
+    Dir["#{rails_view_directory}/**/*#{@extension}" ].each do |full_erb_file_path|
       erb_file = full_erb_file_path[@rails_root.length,full_erb_file_path.length]
       rails_translation_store.start_new_context( convert_path_to_key_path( erb_file.to_s ) )
       erb_file = ErbFile.load( full_erb_file_path )


### PR DESCRIPTION
Hi! I was using herbgobbler to prepare one of my projects for localization, but I ran into the issue of not being able to use custom extensions. I prefer to use .html, rather than .html.erb (not exactly standard, but I prefer the shorter extension). Unfortunately, herbgobbler didn't support custom extensions, so I went ahead and added support for that.

Along with that, I rewrote the gobbler executable to use optparse, which makes it much easier to add more arguments if there is ever a need to do so. 

I also corrected the tr8n link in the README.

I tested this thoroughly,  but testing it some more wouldn't be a bad idea.

Thanks!